### PR TITLE
docs: add quick start steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,8 @@ reduce exposure to harmful content.
 - Chrome Web Store draft
 
 MIT License
+
+## Quick start
+1) Load unpacked
+2) Toggle Enable
+3) Edit data/blocklist.json


### PR DESCRIPTION
### Summary
Adds a short **Quick start** section to the README so new users can load and test the extension fast.

### What changed
- README: steps to
  1) enable Developer Mode and **Load unpacked**
  2) toggle **Enable protection**
  3) edit `data/blocklist.json`
  4) verify the interstitial appears

### Why
Improves first-run UX and reduces setup questions.

### How to test
1. Open `chrome://extensions` → Developer mode → **Load unpacked** → this repo.
2. Open the popup and enable protection.
3. Add a test domain (e.g., `example-bad-site.com`) to `data/blocklist.json`.
4. Visit that domain and confirm the **blocked** interstitial.
5. Lint passes in CI.

### Checklist
- [x] Docs updated
- [x] CI passes
- [ ] N/A – code changes, tests
